### PR TITLE
Add configurable workgroup api timeout and increase it

### DIFF
--- a/config/install/stanford_samlauth.settings.yml
+++ b/config/install/stanford_samlauth.settings.yml
@@ -11,4 +11,5 @@ role_mapping:
   workgroup_api:
     cert: ''
     key: ''
+    timeout: 30
   mapping: {}

--- a/config/schema/stanford_samlauth.schema.yml
+++ b/config/schema/stanford_samlauth.schema.yml
@@ -64,6 +64,9 @@ stanford_samlauth.settings:
             key:
               type: string
               label: Path to Workgroup API Key file
+            timeout:
+              type: integer
+              label: API Request timeout limit
         reevaluate:
           type: string
           label: Reevaluation rule

--- a/src/Service/WorkgroupApi.php
+++ b/src/Service/WorkgroupApi.php
@@ -159,11 +159,12 @@ class WorkgroupApi implements WorkgroupApiInterface {
    *   API response or false if fails.
    */
   protected function callApi(string $workgroup = NULL, string $sunet = NULL): ?array {
+    $config = $this->configFactory->get('stanford_samlauth.settings');
     $options = [
       'cert' => $this->getCert(),
       'ssl_key' => $this->getKey(),
       'verify' => TRUE,
-      'timeout' => 5,
+      'timeout' => $config->get('role_mapping.workgroup_api.timeout') ?: 30,
       'query' => [
         'type' => $workgroup ? 'workgroup' : 'user',
         'id' => $workgroup ?: $sunet,

--- a/stanford_samlauth.install
+++ b/stanford_samlauth.install
@@ -113,3 +113,13 @@ function stanford_samlauth_install() {
     ->set('match_noredirect_pages', "/jsonapi\r\n/jsonapi/*\r\n/subrequests")
     ->save();
 }
+
+/**
+ * Add request timeout config value.
+ */
+function stanford_samlauth_update_1001() {
+  \Drupal::configFactory()
+    ->getEditable('stanford_samlauth.settings')
+    ->set('role_mapping.workgroup_api.timeout', 30)
+    ->save();
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Increase api timeout to to 30 seconds
- allow timeout changes via config
