### PR TITLE
Don't force a redirect back to the homepage 2.x

### DIFF
--- a/src/Plugin/Block/SamlLoginBlock.php
+++ b/src/Plugin/Block/SamlLoginBlock.php
@@ -9,7 +9,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Routing\RedirectDestination;
+use Drupal\Core\Routing\RedirectDestinationInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\Translatablemarkup;
 use Drupal\Core\Url;
@@ -27,9 +27,9 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
   /**
    * RedirectDestination service.
    *
-   * @var \Drupal\Core\Routing\RedirectDestination
+   * @var \Drupal\Core\Routing\RedirectDestinationInterface
    */
-  private RedirectDestination $redirectDestination;
+  private RedirectDestinationInterface $redirectDestination;
 
   /**
    * PathMatcher service.
@@ -65,7 +65,7 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
    * @param \Drupal\Core\Path\PathMatcherInterface $pathMatcher
    *   The path matcher service.
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, RedirectDestination $redirectDestination, PathMatcherInterface $pathMatcher) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, RedirectDestinationInterface $redirectDestination, PathMatcherInterface $pathMatcher) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->redirectDestination = $redirectDestination;
     $this->pathMatcher = $pathMatcher;
@@ -133,7 +133,7 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
    *   Either an empty array or a `['destination' => ...]` array suitable for
    *   passing as route parameters to the login URL.
    */
-  private function getDestination(): array {
+  protected function getDestination(): array {
     if ($this->pathMatcher->isFrontPage()) {
       return [];
     }

--- a/src/Plugin/Block/SamlLoginBlock.php
+++ b/src/Plugin/Block/SamlLoginBlock.php
@@ -5,12 +5,14 @@ namespace Drupal\stanford_samlauth\Plugin\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RedirectDestination;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\path_alias\AliasManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a 'Saml Login Block' block.
@@ -23,11 +25,25 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
-   * Current uri the block is displayed on.
+   * RedirectDestination service.
+   *
+   * @var \Drupal\Core\Routing\RedirectDestination
+   */
+  private RedirectDestination $redirectDestination;
+
+  /**
+   * Internal path to the front page.
    *
    * @var string
    */
-  protected $currentUri;
+  private mixed $frontPage;
+
+  /**
+   * PathAliasManager service.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  private AliasManagerInterface $pathAliasManager;
 
   /**
    * {@inheritDoc}
@@ -37,7 +53,9 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('request_stack')
+      $container->get('redirect.destination'),
+      $container->get('config.factory'),
+      $container->get('path_alias.manager')
     );
   }
 
@@ -50,12 +68,15 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
    *   Block machine name.
    * @param array $plugin_definition
    *   Plugin definition.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-   *   Current request stack object.
+   * @param \Drupal\Core\Routing\RedirectDestination $redirectDestination
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   * @param \Drupal\path_alias\AliasManagerInterface $pathAliasManager
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, RequestStack $requestStack) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, RedirectDestination $redirectDestination, ConfigFactoryInterface $configFactory, AliasManagerInterface $pathAliasManager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->currentUri = $requestStack->getCurrentRequest()?->getPathInfo();
+    $this->redirectDestination = $redirectDestination;
+    $this->frontPage = $configFactory->get('system.site')->get('page.front');
+    $this->pathAliasManager = $pathAliasManager;
   }
 
   /**
@@ -105,10 +126,32 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
   }
 
   /**
+   * Get the destination of the current request.
+   *
+   * * Returns any destination parameter if present in the current URL.
+   *   E.g. `stanford.edu?destination=/foo/bar`.
+   * * Otherwise the current path.
+   * * Except if that's the homepage, in which case an empty array is returned.
+   *
+   * This ensures that someone clicking the log-in button on the homepage does
+   * not get redirected back to the homepage post-login and instead sees the
+   * standard post-login page (dashboard, etc.).
+   *
+   * @return array
+   */
+  private function getDestination(): array {
+    $front_alias = $this->pathAliasManager->getAliasByPath($this->frontPage);
+    if ($this->redirectDestination->get() === '/' || $this->redirectDestination->get() === $front_alias) {
+      return [];
+    }
+    return $this->redirectDestination->getAsArray();
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function build() {
-    $url = Url::fromRoute('samlauth.saml_controller_login', ['destination' => $this->currentUri]);
+    $url = Url::fromRoute('samlauth.saml_controller_login', $this->getDestination());
     $build = [];
     $build['login'] = [
       '#type' => 'html_tag',

--- a/src/Plugin/Block/SamlLoginBlock.php
+++ b/src/Plugin/Block/SamlLoginBlock.php
@@ -6,14 +6,13 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RedirectDestination;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\Translatablemarkup;
 use Drupal\Core\Url;
-use Drupal\path_alias\AliasManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -33,18 +32,11 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
   private RedirectDestination $redirectDestination;
 
   /**
-   * Internal path to the front page.
+   * PathMatcher service.
    *
-   * @var string
+   * @var \Drupal\Core\Path\PathMatcherInterface
    */
-  private mixed $frontPage;
-
-  /**
-   * PathAliasManager service.
-   *
-   * @var \Drupal\path_alias\AliasManagerInterface
-   */
-  private AliasManagerInterface $pathAliasManager;
+  private PathMatcherInterface $pathMatcher;
 
   /**
    * {@inheritDoc}
@@ -55,8 +47,7 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $plugin_id,
       $plugin_definition,
       $container->get('redirect.destination'),
-      $container->get('config.factory'),
-      $container->get('path_alias.manager')
+      $container->get('path.matcher')
     );
   }
 
@@ -70,14 +61,14 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
    * @param array $plugin_definition
    *   Plugin definition.
    * @param \Drupal\Core\Routing\RedirectDestination $redirectDestination
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   * @param \Drupal\path_alias\AliasManagerInterface $pathAliasManager
+   *   The redirect destination service.
+   * @param \Drupal\Core\Path\PathMatcherInterface $pathMatcher
+   *   The path matcher service.
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, RedirectDestination $redirectDestination, ConfigFactoryInterface $configFactory, AliasManagerInterface $pathAliasManager) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, RedirectDestination $redirectDestination, PathMatcherInterface $pathMatcher) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->redirectDestination = $redirectDestination;
-    $this->frontPage = $configFactory->get('system.site')->get('page.front');
-    $this->pathAliasManager = $pathAliasManager;
+    $this->pathMatcher = $pathMatcher;
   }
 
   /**
@@ -129,20 +120,21 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
   /**
    * Get the destination of the current request.
    *
-   * * Returns any destination parameter if present in the current URL.
-   *   E.g. `stanford.edu?destination=/foo/bar`.
-   * * Otherwise the current path.
-   * * Except if that's the homepage, in which case an empty array is returned.
-   *
-   * This ensures that someone clicking the log-in button on the homepage does
-   * not get redirected back to the homepage post-login and instead sees the
+   * When the block is rendered on the front page, returns an empty array so
+   * that no `destination` parameter is appended to the login URL. This ensures
+   * that someone clicking the log-in button on the homepage does not get
+   * redirected back to the homepage post-login and instead sees the site's
    * standard post-login page (dashboard, etc.).
    *
+   * Otherwise, returns the current redirect destination as an array so that
+   * the user is returned to the page they logged in from.
+   *
    * @return array
+   *   Either an empty array or a `['destination' => ...]` array suitable for
+   *   passing as route parameters to the login URL.
    */
   private function getDestination(): array {
-    $front_alias = $this->pathAliasManager->getAliasByPath($this->frontPage);
-    if ($this->redirectDestination->get() === '/' || $this->redirectDestination->get() === $front_alias) {
+    if ($this->pathMatcher->isFrontPage()) {
       return [];
     }
     return $this->redirectDestination->getAsArray();

--- a/src/Plugin/Block/SamlLoginBlock.php
+++ b/src/Plugin/Block/SamlLoginBlock.php
@@ -99,7 +99,7 @@ class SamlLoginBlock extends BlockBase implements ContainerFactoryPluginInterfac
     $context = parent::getCacheContexts();
     // Make the block cache different for each page since the login link has a
     // destination parameter.
-    return Cache::mergeContexts($context, ['url.path']);
+    return Cache::mergeContexts($context, ['url']);
   }
 
   /**

--- a/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
+++ b/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
@@ -5,6 +5,8 @@ namespace Drupal\Tests\stanford_samlauth\Unit\Plugin\Block;
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Form\FormState;
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Routing\RedirectDestination;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\stanford_samlauth\Plugin\Block\SamlLoginBlock;
@@ -24,24 +26,52 @@ class SamlLoginBlockTest extends UnitTestCase {
   protected $block;
 
   /**
+   * The path matcher mock.
+   *
+   * @var \PHPUnit\Framework\MockObject\MockObject|\Drupal\Core\Path\PathMatcherInterface
+   */
+  protected $pathMatcher;
+
+  /**
+   * The URL generator mock.
+   *
+   * @var \PHPUnit\Framework\MockObject\MockObject|\Drupal\Core\Routing\UrlGeneratorInterface
+   */
+  protected $urlGenerator;
+
+  /**
+   * The redirect destination mock.
+   *
+   * @var \PHPUnit\Framework\MockObject\MockObject|\Drupal\Core\Routing\RedirectDestination
+   */
+  protected $redirectDestination;
+
+  /**
    * {@inheritDoc}
    */
   public function setup(): void {
     parent::setUp();
 
-    $url_generator = $this->createMock(UrlGeneratorInterface::class);
-    $url_generator->method('generateFromRoute')->willReturn('/foo-bar');
+    $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+    $this->urlGenerator->method('generateFromRoute')->willReturn('/foo-bar');
 
     $request_stack = new RequestStack();
 
     $context_manager = $this->createMock(CacheContextsManager::class);
     $context_manager->method('assertValidTokens')->willReturn(TRUE);
 
+    $this->redirectDestination = $this->createMock(RedirectDestination::class);
+    $this->redirectDestination->method('getAsArray')->willReturn(['destination' => '/some/path']);
+
+    $this->pathMatcher = $this->createMock(PathMatcherInterface::class);
+
     $container = new ContainerBuilder();
     $container->set('string_translation', $this->getStringTranslationStub());
-    $container->set('url_generator', $url_generator);
+    $container->set('url_generator', $this->urlGenerator);
     $container->set('request_stack', $request_stack);
     $container->set('cache_contexts_manager', $context_manager);
+    $container->set('redirect.destination', $redirect_destination);
+    $container->set('path.matcher', $this->pathMatcher);
     \Drupal::setContainer($container);
 
     $this->block = SamlLoginBlock::create($container, [], 'saml_login', ['provider' => 'stanford_samlauth']);
@@ -83,10 +113,28 @@ class SamlLoginBlockTest extends UnitTestCase {
    * Test build render array is structured correctly.
    */
   public function testBuild() {
+    $this->pathMatcher->method('isFrontPage')->willReturn(FALSE);
+    $this->urlGenerator->expects($this->once())
+      ->method('generateFromRoute')
+      ->with('samlauth.saml_controller_login', ['destination' => '/some/path'])
+      ->willReturn('/foo-bar');
     $build = $this->block->build();
     $this->assertCount(1, $build);
     $this->assertArrayHasKey('login', $build);
     $this->assertEquals( 'html_tag', $build['login']['#type']);
+    $this->assertEquals('/foo-bar', $build['login']['#attributes']['href']);
+  }
+
+  /**
+   * Test that no destination is forwarded when on the front page.
+   */
+  public function testBuildOnFrontPage() {
+    $this->pathMatcher->method('isFrontPage')->willReturn(TRUE);
+    $this->urlGenerator->expects($this->once())
+      ->method('generateFromRoute')
+      ->with('samlauth.saml_controller_login', [])
+      ->willReturn('/foo-bar');
+    $build = $this->block->build();
     $this->assertEquals('/foo-bar', $build['login']['#attributes']['href']);
   }
 

--- a/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
+++ b/tests/src/Unit/Plugin/Block/SamlLoginBlockTest.php
@@ -6,7 +6,7 @@ use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Path\PathMatcherInterface;
-use Drupal\Core\Routing\RedirectDestination;
+use Drupal\Core\Routing\RedirectDestinationInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\stanford_samlauth\Plugin\Block\SamlLoginBlock;
@@ -42,7 +42,7 @@ class SamlLoginBlockTest extends UnitTestCase {
   /**
    * The redirect destination mock.
    *
-   * @var \PHPUnit\Framework\MockObject\MockObject|\Drupal\Core\Routing\RedirectDestination
+   * @var \PHPUnit\Framework\MockObject\MockObject|\Drupal\Core\Routing\RedirectDestinationInterface
    */
   protected $redirectDestination;
 
@@ -60,7 +60,7 @@ class SamlLoginBlockTest extends UnitTestCase {
     $context_manager = $this->createMock(CacheContextsManager::class);
     $context_manager->method('assertValidTokens')->willReturn(TRUE);
 
-    $this->redirectDestination = $this->createMock(RedirectDestination::class);
+    $this->redirectDestination = $this->createMock(RedirectDestinationInterface::class);
     $this->redirectDestination->method('getAsArray')->willReturn(['destination' => '/some/path']);
 
     $this->pathMatcher = $this->createMock(PathMatcherInterface::class);
@@ -70,7 +70,7 @@ class SamlLoginBlockTest extends UnitTestCase {
     $container->set('url_generator', $this->urlGenerator);
     $container->set('request_stack', $request_stack);
     $container->set('cache_contexts_manager', $context_manager);
-    $container->set('redirect.destination', $redirect_destination);
+    $container->set('redirect.destination', $this->redirectDestination);
     $container->set('path.matcher', $this->pathMatcher);
     \Drupal::setContainer($container);
 
@@ -98,7 +98,7 @@ class SamlLoginBlockTest extends UnitTestCase {
    * Test anonymous users would access the block, authenticated would not.
    */
   public function testAccess() {
-    $this->assertContains('url.path', $this->block->getCacheContexts());
+    $this->assertContains('url', $this->block->getCacheContexts());
 
     $account = $this->createMock(AccountInterface::class);
     $account->method('isAnonymous')->willReturn(TRUE);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
On HSDP, we want to get more content editors aware of Dashboard.  We surmise that the vast majority of people who log in on the homepage are not actually trying to edit the homepage, but just log into the site to do their normal tasks.  Therefore we don't want to redirect those people back to the homepage, but let them arrive on the site's standard post-log-in page (in this case, the dashboard).

# Review By (Date)
standard timing

# Criticality
Affects every site on HSDP.  It's probably useful for other sites that use this module.

# Urgency
Normal


## Setup tasks and/or behavior to test
1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Try clicking the log-in button on the homepage.  You end up on the site's default log-in page.  
4. try logging in on a non-homepage, and confirm that the behaviour is unchanged

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory?

none


## Front End Validation
- [ ] ~~Design is approved by @ user?~~ N/A
- [ ] ~~HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?~~ N/A
- [ ] ~~Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?~~ N/A
- [ ] ~~Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?~~ N/A
- [ ] ~~Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?~~ N/A

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- ClickUp ticket(s) https://fourkitchens.clickup.com/t/36718269/SHS-6607
- Anyone who should be notified? (`@ahughes3`)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
